### PR TITLE
mount.sh: add sync option to avoid data loss

### DIFF
--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -40,5 +40,5 @@ if findmnt -rno SOURCE,TARGET $DEVNAME >/dev/null; then
 else
     echo "Mounting - Source: $DEVNAME - Destination: $MOUNT_POINT" >> /usr/src/mount.log
     mkdir -p $MOUNT_POINT
-    mount -t $ID_FS_TYPE -o rw $DEVNAME $MOUNT_POINT
+    mount -t $ID_FS_TYPE -o rw,sync $DEVNAME $MOUNT_POINT
 fi


### PR DESCRIPTION
The unmounting of the disk happens after it has been removed. Mounting with synchronous writes avoid data loss on filesystems that support it like ext4.

Change-type: patch